### PR TITLE
Bevy 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ opt-level = 1
 opt-level = 3
 
 [dependencies]
-bevy = { version = "0.15.0", features = ["dynamic_linking"] }
-bevy_rapier3d = { version = "0.28.0", features = [
+bevy = { version = "0.16.0", features = ["dynamic_linking"] }
+bevy_rapier3d = { version = "0.31.0", features = [
     "simd-stable",
     "debug-render-3d",
 ] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ fn main() {
         .add_plugins((
             DefaultPlugins.set(ImagePlugin::default_nearest()),
             #[cfg(not(target_arch = "wasm32"))]
-            WireframePlugin,
+            WireframePlugin::default(),
         ))
         .add_plugins(RapierPhysicsPlugin::<NoUserData>::default())
         .add_plugins(RapierDebugRenderPlugin::default())
@@ -77,9 +77,9 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut rapier_config: Query<&mut RapierConfiguration>,
 ) {
-    let mut rapier_config = rapier_config.single_mut();
+    let rapier_config = rapier_config.single_mut();
     // Set gravity to 0.0.
-    rapier_config.gravity = Vec3::new(15.0, 0.0, 0.0);
+    rapier_config.unwrap().gravity = Vec3::new(15.0, 0.0, 0.0);
 
     let debug_material = materials.add(StandardMaterial {
         base_color_texture: Some(images.add(uv_debug_texture())),
@@ -327,7 +327,7 @@ fn read_character_controller_collisions(
     accumulated_mouse_motion: Res<AccumulatedMouseMotion>,
     mut commands: Commands,
 ) {
-    let output = match paddle_outputs.get_single() {
+    let output = match paddle_outputs.single() {
         Ok(controller) => controller,
         Err(_) => return,
     };


### PR DESCRIPTION
## Summary by Sourcery

Upgrade Bevy and Rapier dependencies and adapt the example code to match their updated APIs.

Enhancements:
- Switch to WireframePlugin::default() and updated Bevy import paths
- Replace get_single() with Query::single() and unwrap the result when configuring gravity
- Adjust function parameters and iterator bindings for image assets, query results, and collision event iteration

Build:
- Bump bevy dependency from 0.15.0 to 0.16.0
- Bump bevy_rapier3d dependency from 0.28.0 to 0.31.0
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Bevy and bevy_rapier3d dependencies and adjust code for compatibility and clarity in `main.rs`.
> 
>   - **Dependencies**:
>     - Update `bevy` to version `0.16.0` and `bevy_rapier3d` to version `0.31.0` in `Cargo.toml`.
>   - **Code Adjustments**:
>     - Remove unused import `debug` from `main.rs`.
>     - Change `WireframePlugin` initialization to `WireframePlugin::default()` in `main.rs`.
>     - Use `rapier_config.unwrap().gravity` instead of `rapier_config.gravity` in `setup()` in `main.rs`.
>     - Simplify `match` statement in `read_character_controller_collisions()` by using `paddle_outputs.single()` in `main.rs`.
>   - **Miscellaneous**:
>     - Remove commented-out docstring in `main.rs`.
>     - Minor refactoring in `spawn_border()` and `move_paddle()` functions in `main.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cleder%2Fbrkrs&utm_source=github&utm_medium=referral)<sup> for 996dce26d6f4b8d3ef2f270d8f39b60b8bf79dc5. You can [customize](https://app.ellipsis.dev/cleder/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->